### PR TITLE
feat: resolve Apex Test Suites from commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,17 @@ Requires [git](https://git-scm.com/downloads) to be installed and that it can be
 
 ### Create a config file
 
-Create a `.apextestsgitdeltarc` file in your **Salesforce DX project root** with the regular expression:
+Create a `.apextestsgitdeltarc` file in your **Salesforce DX project root**. The file accepts up to two non-empty lines:
+
+- **Line 1 (required):** regular expression used to capture individual Apex test class names.
+- **Line 2 (optional):** regular expression used to capture [Apex Test Suite](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_apextestsuite.htm) names. When provided, each matched suite name is looked up at the `--to` commit as `<suiteName>.testSuite-meta.xml` inside one of your `sfdx-project.json` package directories, and the `<testClassName>` entries are merged into the output.
 
 ```regex
 [Aa][Pp][Ee][Xx]::(.*?)::[Aa][Pp][Ee][Xx]
+[Ss][Uu][Ii][Tt][Ee]::(.*?)::[Ss][Uu][Ii][Tt][Ee]
 ```
+
+If line 2 is omitted or blank, suite parsing is disabled (fully backward compatible).
 
 ### Use the format in commit messages
 
@@ -60,7 +66,22 @@ Create a `.apextestsgitdeltarc` file in your **Salesforce DX project root** with
 fix: update triggers Apex::AccountTriggerHandlerTest OpportunityTriggerHandlerTest::Apex
 chore: add sandbox setup Apex::PrepareMySandboxTest::Apex
 fix: resolve quoting issues Apex::QuoteControllerTest::Apex
+chore: regression pass Suite::AccountRegressionSuite::Suite
 ```
+
+#### Apex Test Suite wildcards
+
+The plugin understands the same `<testClassName>` wildcard conventions [documented by Salesforce for ApexTestSuite metadata](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_apextestsuite.htm):
+
+| `<testClassName>` entry          | Resolution at `--to`                                                            |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| `LocalTestClass`                 | Literal local class. Validated like any class name from a commit message.       |
+| `A*Class`, `*Test`, `Foo_*`      | Local wildcard. Expanded against all `.cls` files in your package directories.  |
+| `*`                              | Expands to every local Apex class at `--to`.                                    |
+| `Namespace1.NamespacedTestClass` | Managed-package test. Passed through to the output as-is (not validated).       |
+| `Namespace1.*`                   | Managed-package wildcard. Passed through as-is; Salesforce resolves at runtime. |
+
+Wildcard patterns that match nothing locally produce a warning and contribute no tests.
 
 ### Run the command to extract tests
 

--- a/messages/delta.md
+++ b/messages/delta.md
@@ -4,11 +4,12 @@ Determine Apex tests by parsing commit messages.
 
 # description
 
-Determine Apex tests for incremental deployments by parsing commit messages between 2 commits.
+Determine Apex tests for incremental deployments by parsing commit messages between 2 commits. Commit messages may reference individual Apex test classes (e.g. `Apex::MyTest::Apex`) or Apex Test Suites (e.g. `Suite::MyTestSuite::Suite`) when a suite regex is configured on the 2nd line of `.apextestsgitdeltarc`. Matched suites are resolved by reading the corresponding `<suiteName>.testSuite-meta.xml` at the `--to` commit and merging its `<testClassName>` entries into the output.
 
 # examples
 
 - `sf atgd delta --from "HEAD~1" --to "HEAD"`
+- `sf atgd delta --from "HEAD~1" --to "HEAD" -v`
 
 # flags.from.summary
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@oclif/core": "^4.2.7",
         "@salesforce/core": "^8.8.2",
         "@salesforce/sf-plugins-core": "^12.1.4",
+        "fast-xml-parser": "^5.7.1",
         "simple-git": "^3.28.0"
       },
       "devDependencies": {
@@ -942,6 +943,26 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
@@ -2472,6 +2493,17 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ]
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6813,7 +6845,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
       "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6825,10 +6856,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
-      "dev": true,
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -6836,9 +6866,10 @@
         }
       ],
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -9870,7 +9901,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
       "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11609,7 +11639,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
       "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@oclif/core": "^4.2.7",
     "@salesforce/core": "^8.8.2",
     "@salesforce/sf-plugins-core": "^12.1.4",
+    "fast-xml-parser": "^5.7.1",
     "simple-git": "^3.28.0"
   },
   "devDependencies": {

--- a/src/commands/atgd/delta.ts
+++ b/src/commands/atgd/delta.ts
@@ -39,12 +39,16 @@ export default class ApexTestDelta extends SfCommand<TestDeltaResult> {
     const result = await extractTestClasses(flags['from'], flags['to'], flags['skip-test-validation']);
     const tests = result.validatedClasses;
     const warnings = result.warnings;
+    const suites = result.suites;
     if (warnings.length > 0) {
       warnings.forEach((warning) => {
         this.warn(warning);
       });
     }
+    if (suites.length > 0) {
+      this.log(`Resolved test suites: ${suites.join(' ')}`);
+    }
     this.log(tests);
-    return { tests, warnings };
+    return { tests, warnings, suites };
   }
 }

--- a/src/service/extractTestClasses.ts
+++ b/src/service/extractTestClasses.ts
@@ -1,17 +1,18 @@
 'use strict';
 
 import { retrieveCommitMessages } from './retrieveCommitMessages.js';
+import { resolveTestSuites } from './resolveTestSuites.js';
 import { validateClassPaths } from './validateClassPaths.js';
 import { gitAdapter } from './gitAdapter.js';
 
 export async function extractTestClasses(
   fromRef: string,
   toRef: string,
-  skipValidate: boolean
-): Promise<{ validatedClasses: string; warnings: string[] }> {
-  const testClasses: Set<string> = new Set();
+  skipValidate: boolean,
+): Promise<{ validatedClasses: string; warnings: string[]; suites: string[] }> {
+  const localTestClasses: Set<string> = new Set();
   const git = gitAdapter();
-  const { repoRoot, matchedMessages } = await retrieveCommitMessages(fromRef, toRef, git);
+  const { repoRoot, matchedMessages, matchedSuites } = await retrieveCommitMessages(fromRef, toRef, git);
 
   matchedMessages.forEach((message: string) => {
     // Split the commit message by commas or spaces
@@ -21,28 +22,41 @@ export async function extractTestClasses(
       // Remove leading/trailing whitespaces and add non-empty strings to the set
       const trimmedClass = testClass.trim();
       if (trimmedClass !== '') {
-        testClasses.add(trimmedClass);
+        localTestClasses.add(trimmedClass);
       }
     });
   });
 
-  let sortedClasses: string[] = Array.from(testClasses).sort((a, b) => a.localeCompare(b));
+  const suiteResult = await resolveTestSuites(matchedSuites, toRef, repoRoot, git);
+  suiteResult.localClasses.forEach((className) => localTestClasses.add(className));
+
+  const sortedLocal = Array.from(localTestClasses).sort((a, b) => a.localeCompare(b));
 
   if (skipValidate) {
-    return { validatedClasses: sortedClasses.join(' '), warnings: [] };
+    const combined = mergeAndSort(sortedLocal, suiteResult.namespacedClasses);
+    return {
+      validatedClasses: combined,
+      warnings: suiteResult.warnings,
+      suites: suiteResult.resolvedSuites,
+    };
   }
 
-  const result =
-    sortedClasses.length > 0
-      ? await validateClassPaths(sortedClasses, toRef, repoRoot, git)
-      : { validatedClasses: new Set(), warnings: [] };
+  const validation =
+    sortedLocal.length > 0
+      ? await validateClassPaths(sortedLocal, toRef, repoRoot, git)
+      : { validatedClasses: new Set<string>(), warnings: [] as string[] };
 
-  let validatedClasses: string = '';
-  if (result.validatedClasses.size > 0) {
-    sortedClasses = Array.from(result.validatedClasses) as string[];
-    sortedClasses = sortedClasses.sort((a, b) => a.localeCompare(b));
-    validatedClasses = sortedClasses.join(' ');
-  }
+  const combined = mergeAndSort(Array.from(validation.validatedClasses), suiteResult.namespacedClasses);
+  return {
+    validatedClasses: combined,
+    warnings: [...suiteResult.warnings, ...validation.warnings],
+    suites: suiteResult.resolvedSuites,
+  };
+}
 
-  return { validatedClasses, warnings: result.warnings };
+function mergeAndSort(localClasses: string[], namespacedClasses: Set<string>): string {
+  const merged = new Set<string>([...localClasses, ...namespacedClasses]);
+  return Array.from(merged)
+    .sort((a, b) => a.localeCompare(b))
+    .join(' ');
 }

--- a/src/service/resolveTestSuites.ts
+++ b/src/service/resolveTestSuites.ts
@@ -1,0 +1,125 @@
+'use strict';
+/* eslint-disable no-await-in-loop */
+
+import { basename } from 'node:path';
+import { SimpleGit } from 'simple-git';
+import { XMLParser } from 'fast-xml-parser';
+
+import { getPackageDirectories } from './getPackageDirectories.js';
+
+export type ResolvedTestSuites = {
+  localClasses: Set<string>;
+  namespacedClasses: Set<string>;
+  resolvedSuites: string[];
+  warnings: string[];
+};
+
+export async function resolveTestSuites(
+  suiteNames: string[],
+  toCommitHash: string,
+  repoRoot: string,
+  git: SimpleGit,
+): Promise<ResolvedTestSuites> {
+  const localClasses: Set<string> = new Set();
+  const namespacedClasses: Set<string> = new Set();
+  const resolvedSuites: string[] = [];
+  const warnings: string[] = [];
+
+  if (suiteNames.length === 0) {
+    return { localClasses, namespacedClasses, resolvedSuites, warnings };
+  }
+
+  const packageDirectories = await getPackageDirectories(repoRoot);
+  const parser = new XMLParser({ isArray: (name) => name === 'testClassName' });
+  const uniqueSuites = Array.from(new Set(suiteNames));
+  const localClassInventory = await listLocalClasses(packageDirectories, toCommitHash, git);
+
+  for (const suiteName of uniqueSuites) {
+    const suiteFile = `${suiteName}.testSuite-meta.xml`;
+    let matchedPath: string | undefined;
+    for (const packageDirectory of packageDirectories) {
+      const files = (await git.raw('ls-tree', '--name-only', '-r', toCommitHash, packageDirectory)).trim().split('\n');
+      matchedPath = files.find((file) => file.endsWith(`/${suiteFile}`) || file === suiteFile);
+      if (matchedPath) break;
+    }
+
+    if (!matchedPath) {
+      warnings.push(
+        `The test suite ${suiteName} was not found in any package directory at commit ${toCommitHash} and will not contribute test classes.`,
+      );
+      continue;
+    }
+
+    const xml = await git.show([`${toCommitHash}:${matchedPath}`]);
+    const parsed = parser.parse(xml) as { ApexTestSuite?: { testClassName?: string[] } };
+    const entries = parsed?.ApexTestSuite?.testClassName ?? [];
+    if (entries.length === 0) {
+      warnings.push(`The test suite ${suiteName} at commit ${toCommitHash} has no testClassName entries.`);
+      continue;
+    }
+
+    expandSuiteEntries(suiteName, entries, localClassInventory, localClasses, namespacedClasses, warnings);
+    resolvedSuites.push(suiteName);
+  }
+
+  resolvedSuites.sort((a, b) => a.localeCompare(b));
+  return { localClasses, namespacedClasses, resolvedSuites, warnings };
+}
+
+async function listLocalClasses(
+  packageDirectories: string[],
+  toCommitHash: string,
+  git: SimpleGit,
+): Promise<Set<string>> {
+  const classes: Set<string> = new Set();
+  for (const directory of packageDirectories) {
+    const files = (await git.raw('ls-tree', '--name-only', '-r', toCommitHash, directory)).trim().split('\n');
+    for (const file of files) {
+      if (file.endsWith('.cls')) {
+        classes.add(basename(file, '.cls'));
+      }
+    }
+  }
+  return classes;
+}
+
+function expandSuiteEntries(
+  suiteName: string,
+  entries: string[],
+  localClassInventory: Set<string>,
+  localClasses: Set<string>,
+  namespacedClasses: Set<string>,
+  warnings: string[],
+): void {
+  for (const raw of entries) {
+    const entry = String(raw).trim();
+    if (entry === '') continue;
+
+    // Namespaced entries (Namespace.Class or Namespace.*) cannot be resolved from the local source tree.
+    // They are passed through to the output so Salesforce can resolve the managed-package test class at runtime.
+    if (entry.includes('.')) {
+      namespacedClasses.add(entry);
+      continue;
+    }
+
+    if (!entry.includes('*')) {
+      localClasses.add(entry);
+      continue;
+    }
+
+    const matches = matchWildcard(entry, localClassInventory);
+    if (matches.length === 0) {
+      warnings.push(
+        `The test suite ${suiteName} pattern '${entry}' matched no local Apex classes and will not contribute tests.`,
+      );
+      continue;
+    }
+    matches.forEach((className) => localClasses.add(className));
+  }
+}
+
+function matchWildcard(pattern: string, inventory: Set<string>): string[] {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  const regex = new RegExp(`^${escaped}$`);
+  return Array.from(inventory).filter((className) => regex.test(className));
+}

--- a/src/service/retrieveCommitMessages.ts
+++ b/src/service/retrieveCommitMessages.ts
@@ -9,8 +9,8 @@ import { getRepoRoot } from './getRepoRoot.js';
 export async function retrieveCommitMessages(
   fromCommit: string,
   toCommit: string,
-  git: SimpleGit
-): Promise<{ repoRoot: string; matchedMessages: string[] }> {
+  git: SimpleGit,
+): Promise<{ repoRoot: string; matchedMessages: string[]; matchedSuites: string[] }> {
   const repoRoot = await getRepoRoot(git);
   process.chdir(repoRoot);
   const result: LogResult<string | DefaultLogFields> = await git.log({ from: fromCommit, to: toCommit, format: '%s' });
@@ -18,26 +18,41 @@ export async function retrieveCommitMessages(
   // Filter only entries that match the DefaultLogFields type
   const commitMessages: string[] = (result.all as DefaultLogFields[]).map((commit) => commit.message);
 
-  //  Read and compile the regex from the specified file
-  let regex: RegExp;
+  //  Read and compile the regex(es) from the specified file
+  //  Line 1 = class regex (required), Line 2 = suite regex (optional)
+  let classRegex: RegExp;
+  let suiteRegex: RegExp | undefined;
   const regexFilePath = resolve(repoRoot, '.apextestsgitdeltarc');
   try {
-    const regexPattern: string = (await readFile(regexFilePath, 'utf-8')).trim();
-    regex = new RegExp(regexPattern, 'g');
+    const lines = (await readFile(regexFilePath, 'utf-8'))
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    classRegex = new RegExp(lines[0], 'g');
+    if (lines[1]) {
+      suiteRegex = new RegExp(lines[1], 'g');
+    }
   } catch (err) {
     throw Error(
-      `The regular expression in '${regexFilePath}' is invalid or the file wasn't found in the repo root folder.`
+      `The regular expression in '${regexFilePath}' is invalid or the file wasn't found in the repo root folder.`,
     );
   }
 
-  //  Filter messages that match the regex
+  //  Filter messages that match the regex(es)
   const matchedMessages: string[] = [];
+  const matchedSuites: string[] = [];
   commitMessages.forEach((message) => {
-    let match;
-    while ((match = regex.exec(message)) !== null) {
-      matchedMessages.push(match[1]);
+    let classMatch;
+    while ((classMatch = classRegex.exec(message)) !== null) {
+      matchedMessages.push(classMatch[1]);
+    }
+    if (suiteRegex) {
+      let suiteMatch;
+      while ((suiteMatch = suiteRegex.exec(message)) !== null) {
+        matchedSuites.push(suiteMatch[1]);
+      }
     }
   });
 
-  return { repoRoot, matchedMessages };
+  return { repoRoot, matchedMessages, matchedSuites };
 }

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -7,4 +7,5 @@ export type SfdxProject = {
 export type TestDeltaResult = {
   tests: string;
   warnings: string[];
+  suites: string[];
 };

--- a/test/commands/delta/testSuite.test.ts
+++ b/test/commands/delta/testSuite.test.ts
@@ -1,0 +1,280 @@
+'use strict';
+
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+import { extractTestClasses } from '../../../src/service/extractTestClasses.js';
+import { gitAdapter } from '../../../src/service/gitAdapter.js';
+import { createTemporaryCommit } from '../../utils/createTemporaryCommit.js';
+import { setupTestRepo } from '../../utils/setupTestRepo.js';
+import { regExFile } from '../../utils/testConstants.js';
+
+const suiteXml = (classes: string[]): string =>
+  [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<ApexTestSuite xmlns="http://soap.sforce.com/2006/04/metadata">',
+    ...classes.map((c) => `    <testClassName>${c}</testClassName>`),
+    '</ApexTestSuite>',
+    '',
+  ].join('\n');
+
+describe('atgd test suite parsing', () => {
+  let tempDir: string;
+  const originalDir = process.cwd();
+
+  beforeAll(async () => {
+    tempDir = await setupTestRepo();
+    const git = gitAdapter();
+
+    // Overwrite the rc file with a two-line version that also recognizes Suite::<name>::Suite markers.
+    await writeFile(
+      regExFile,
+      ['[Aa][Pp][Ee][Xx]::(.*?)::[Aa][Pp][Ee][Xx]', '[Ss][Uu][Ii][Tt][Ee]::(.*?)::[Ss][Uu][Ii][Tt][Ee]'].join('\n'),
+    );
+    await mkdir('force-app/main/default/testSuites', { recursive: true });
+
+    // Seed the repo with test classes referenced directly and via the suite.
+    await createTemporaryCommit(
+      'chore: seed Apex::SeedTest::Apex',
+      'force-app/main/default/classes/SeedTest.cls',
+      'public with sharing class SeedTest {}',
+      git,
+    );
+    await createTemporaryCommit(
+      'chore: add suite members',
+      'force-app/main/default/classes/AccountTest.cls',
+      'public with sharing class AccountTest {}',
+      git,
+    );
+    await createTemporaryCommit(
+      'chore: add second suite member',
+      'force-app/main/default/classes/ContactTest.cls',
+      'public with sharing class ContactTest {}',
+      git,
+    );
+    // Commit the test suite metadata file.
+    await createTemporaryCommit(
+      'chore: add MyRegressionSuite',
+      'force-app/main/default/testSuites/MyRegressionSuite.testSuite-meta.xml',
+      suiteXml(['AccountTest', 'ContactTest']),
+      git,
+    );
+    // Commit referencing the suite in the message.
+    await createTemporaryCommit(
+      'chore: regression pass Suite::MyRegressionSuite::Suite',
+      'force-app/main/default/classes/ContactTest.cls',
+      'public with sharing class ContactTest { /* v2 */ }',
+      git,
+    );
+    // Commit referencing a missing suite plus a direct class.
+    await createTemporaryCommit(
+      'chore: misc Suite::NonExistentSuite::Suite Apex::SeedTest::Apex',
+      'force-app/main/default/classes/SeedTest.cls',
+      'public with sharing class SeedTest { /* v2 */ }',
+      git,
+    );
+    // Commit an empty suite and reference it.
+    await createTemporaryCommit(
+      'chore: add empty suite',
+      'force-app/main/default/testSuites/EmptySuite.testSuite-meta.xml',
+      suiteXml([]),
+      git,
+    );
+    await createTemporaryCommit(
+      'chore: run empty Suite::EmptySuite::Suite',
+      'force-app/main/default/classes/SeedTest.cls',
+      'public with sharing class SeedTest { /* v3 */ }',
+      git,
+    );
+  });
+
+  afterAll(async () => {
+    process.chdir(originalDir);
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+  });
+
+  it('expands a referenced suite into its member classes', async () => {
+    const result = await extractTestClasses('HEAD~4', 'HEAD~3', false);
+    expect(result.validatedClasses).toEqual('AccountTest ContactTest');
+    expect(result.suites).toEqual(['MyRegressionSuite']);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('unions suite members with directly-referenced classes and warns on missing suites', async () => {
+    const result = await extractTestClasses('HEAD~3', 'HEAD~2', false);
+    expect(result.validatedClasses).toEqual('SeedTest');
+    expect(result.suites).toEqual([]);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings.some((w) => w.includes('NonExistentSuite'))).toBe(true);
+  });
+
+  it('skips validation but still expands suite members', async () => {
+    const result = await extractTestClasses('HEAD~4', 'HEAD~3', true);
+    expect(result.validatedClasses).toEqual('AccountTest ContactTest');
+    expect(result.suites).toEqual(['MyRegressionSuite']);
+  });
+
+  it('warns when a suite has no testClassName entries', async () => {
+    const result = await extractTestClasses('HEAD~1', 'HEAD', false);
+    expect(result.validatedClasses).toEqual('');
+    expect(result.suites).toEqual([]);
+    expect(result.warnings.some((w) => w.includes('EmptySuite') && w.includes('no testClassName entries'))).toBe(true);
+  });
+});
+
+describe('atgd test suite wildcards and namespaces', () => {
+  let tempDir: string;
+  const originalDir = process.cwd();
+
+  beforeAll(async () => {
+    tempDir = await setupTestRepo();
+    const git = gitAdapter();
+    await writeFile(
+      regExFile,
+      ['[Aa][Pp][Ee][Xx]::(.*?)::[Aa][Pp][Ee][Xx]', '[Ss][Uu][Ii][Tt][Ee]::(.*?)::[Ss][Uu][Ii][Tt][Ee]'].join('\n'),
+    );
+    await mkdir('force-app/main/default/testSuites', { recursive: true });
+
+    // Local Apex classes that wildcards should match against.
+    await createTemporaryCommit(
+      'chore: add AClass',
+      'force-app/main/default/classes/AClass.cls',
+      'public with sharing class AClass {}',
+      git,
+    );
+    await createTemporaryCommit(
+      'chore: add AnotherClass',
+      'force-app/main/default/classes/AnotherClass.cls',
+      'public with sharing class AnotherClass {}',
+      git,
+    );
+    await createTemporaryCommit(
+      'chore: add AwesomeClass',
+      'force-app/main/default/classes/AwesomeClass.cls',
+      'public with sharing class AwesomeClass {}',
+      git,
+    );
+    await createTemporaryCommit(
+      'chore: add LocalTestClass',
+      'force-app/main/default/classes/LocalTestClass.cls',
+      'public with sharing class LocalTestClass {}',
+      git,
+    );
+    await createTemporaryCommit(
+      'chore: add Unrelated',
+      'force-app/main/default/classes/Unrelated.cls',
+      'public with sharing class Unrelated {}',
+      git,
+    );
+    // The wildcard suite mirrors the API doc example.
+    await createTemporaryCommit(
+      'chore: add WildcardSuite',
+      'force-app/main/default/testSuites/WildcardSuite.testSuite-meta.xml',
+      suiteXml(['LocalTestClass', 'A*Class', 'Namespace1.NamespacedTestClass', 'Namespace1.*']),
+      git,
+    );
+    await createTemporaryCommit(
+      'chore: run Suite::WildcardSuite::Suite',
+      'force-app/main/default/classes/AClass.cls',
+      'public with sharing class AClass { /* v2 */ }',
+      git,
+    );
+    // A second suite using a pattern that doesn't match anything to exercise the no-match warning.
+    await createTemporaryCommit(
+      'chore: add NoMatchSuite',
+      'force-app/main/default/testSuites/NoMatchSuite.testSuite-meta.xml',
+      suiteXml(['Zzz*Nope']),
+      git,
+    );
+    await createTemporaryCommit(
+      'chore: run Suite::NoMatchSuite::Suite',
+      'force-app/main/default/classes/AClass.cls',
+      'public with sharing class AClass { /* v3 */ }',
+      git,
+    );
+    // A suite using pure '*' to grab every local class.
+    await createTemporaryCommit(
+      'chore: add AllSuite',
+      'force-app/main/default/testSuites/AllSuite.testSuite-meta.xml',
+      suiteXml(['*']),
+      git,
+    );
+    await createTemporaryCommit(
+      'chore: run Suite::AllSuite::Suite',
+      'force-app/main/default/classes/AClass.cls',
+      'public with sharing class AClass { /* v4 */ }',
+      git,
+    );
+  });
+
+  afterAll(async () => {
+    process.chdir(originalDir);
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+  });
+
+  it('expands local wildcards and passes namespaced entries through', async () => {
+    // HEAD~5 -> HEAD~4 contains the WildcardSuite reference commit.
+    const result = await extractTestClasses('HEAD~5', 'HEAD~4', false);
+    // 'A*Class' matches AClass, AnotherClass, AwesomeClass.
+    // 'LocalTestClass' is literal local. Namespaced entries pass through.
+    expect(result.validatedClasses).toEqual(
+      'AClass AnotherClass AwesomeClass LocalTestClass Namespace1.* Namespace1.NamespacedTestClass',
+    );
+    expect(result.suites).toEqual(['WildcardSuite']);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('warns when a wildcard pattern matches no local classes', async () => {
+    // HEAD~3 -> HEAD~2 is the NoMatchSuite reference commit.
+    const result = await extractTestClasses('HEAD~3', 'HEAD~2', false);
+    expect(result.validatedClasses).toEqual('');
+    expect(result.suites).toEqual(['NoMatchSuite']);
+    expect(result.warnings.some((w) => w.includes("'Zzz*Nope'") && w.includes('matched no local Apex classes'))).toBe(
+      true,
+    );
+  });
+
+  it("expands a pure '*' wildcard to every local class", async () => {
+    const result = await extractTestClasses('HEAD~1', 'HEAD', false);
+    // Includes every .cls committed prior to HEAD (sfdxConfig file isn't a .cls).
+    const classes = result.validatedClasses.split(' ');
+    expect(classes).toEqual(
+      expect.arrayContaining(['AClass', 'AnotherClass', 'AwesomeClass', 'LocalTestClass', 'Unrelated']),
+    );
+    expect(result.suites).toEqual(['AllSuite']);
+  });
+});
+
+describe('atgd backward-compatible single-line rc', () => {
+  let tempDir: string;
+  const originalDir = process.cwd();
+
+  beforeAll(async () => {
+    tempDir = await setupTestRepo();
+    const git = gitAdapter();
+    await createTemporaryCommit(
+      'chore: initial',
+      'force-app/main/default/classes/InitialTest.cls',
+      'public with sharing class InitialTest {}',
+      git,
+    );
+    await createTemporaryCommit(
+      'chore: only classes Apex::LonelyTest::Apex',
+      'force-app/main/default/classes/LonelyTest.cls',
+      'public with sharing class LonelyTest {}',
+      git,
+    );
+  });
+
+  afterAll(async () => {
+    process.chdir(originalDir);
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+  });
+
+  it('still works with a one-line rc file and leaves suites empty', async () => {
+    const result = await extractTestClasses('HEAD~1', 'HEAD', false);
+    expect(result.validatedClasses).toEqual('LonelyTest');
+    expect(result.suites).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+});


### PR DESCRIPTION
Add an optional 2nd line to .apextestsgitdeltarc for a suite-name regex (e.g. Suite::(.+?)::Suite). Matched suite names are looked up as <name>.testSuite-meta.xml in the sfdx package directories at --to via git show, and their <testClassName> entries are merged into the output alongside any Apex::...::Apex classes.

Supports the full set of Salesforce wildcard conventions inside the suite XML:
  - literal local classes (LocalTestClass)
  - local wildcards (A*Class, *Test, *) expanded against .cls files in the package directories at --to
  - namespaced literals (Namespace.Class) passed through as-is
  - namespaced wildcards (Namespace.*) passed through as-is

TestDeltaResult gains an additive `suites: string[]` field. Behavior is unchanged for users who don't configure a suite regex.