### PR TITLE
feat(deps)!: replace simple-git with @scolladon/tsgit

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           registry-url: 'https://registry.npmjs.org'
 
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           release-type: node
 
   unit-tests:
-    name: Unit Tests (ubuntu-latest, node 20)
+    name: Unit Tests (ubuntu-latest, node 22)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: ['20', '22', '24']
+        node-version: ['22', '24']
     steps:
       - name: Configure git longpaths if on Windows
         if: ${{ runner.os == 'Windows' }}
@@ -48,7 +48,7 @@ jobs:
           SF_DISABLE_TELEMETRY: true
 
       - name: Upload coverage
-        if: runner.os == 'Linux' && matrix.node-version == '20'
+        if: runner.os == 'Linux' && matrix.node-version == '22'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: ['20', '22', '24']
+        node-version: ['22', '24']
     steps:
       - name: Configure git longpaths if on Windows
         if: ${{ runner.os == 'Windows' }}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A Salesforce CLI plugin that extracts Apex test class names from git commit mess
 sf plugins install apex-tests-git-delta
 ```
 
-Requires [git](https://git-scm.com/downloads) installed and available on `PATH`.
+Requires Node.js `>=22.0.0`. No git CLI dependency — git operations are handled entirely in TypeScript.
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@oclif/core": "4.2.7",
         "@salesforce/core": "8.8.2",
         "@salesforce/sf-plugins-core": "12.1.4",
-        "fast-xml-parser": "5.7.1",
-        "simple-git": "3.28.0"
+        "@scolladon/tsgit": "2.0.1",
+        "fast-xml-parser": "5.7.1"
       },
       "devDependencies": {
         "@commitlint/config-conventional": "19.7.1",
@@ -36,7 +36,7 @@
         "wireit": "0.14.12"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -3168,19 +3168,6 @@
         "tslib": "2"
       }
     },
-    "node_modules/@kwsites/file-exists": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
-      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
-      "dependencies": {
-        "debug": "^4.1.1"
-      }
-    },
-    "node_modules/@kwsites/promise-deferred": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
-      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -4435,6 +4422,15 @@
       "integrity": "sha512-BIJyduJC18Kc8z+arUm5AZ9VkPRyw1KKAm+Tk+9LT99eOzhNilyfKzhZ4t+tG2lIGgnJpmytZfVDZ0e2kFul8g==",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@scolladon/tsgit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@scolladon/tsgit/-/tsgit-2.0.1.tgz",
+      "integrity": "sha512-+khAEX4zd2UeMcBQi6Ar8QDH5+IdoUir2LsQTjGNaYgj8wMWnTB5ANYbuGANfY2Um5sD5S/c0S/RZDRFDnm2WA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.22.1"
       }
     },
     "node_modules/@sec-ant/readable-stream": {
@@ -17301,21 +17297,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/simple-git": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
-      "integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@kwsites/file-exists": "^1.1.1",
-        "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.4.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
     "node_modules/simple-swizzle": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "@oclif/core": "4.2.7",
     "@salesforce/core": "8.8.2",
     "@salesforce/sf-plugins-core": "12.1.4",
-    "fast-xml-parser": "5.7.1",
-    "simple-git": "3.28.0"
+    "@scolladon/tsgit": "2.0.1",
+    "fast-xml-parser": "5.7.1"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "19.7.1",
@@ -30,7 +30,7 @@
     "wireit": "0.14.12"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "files": [
     "/lib",

--- a/src/service/extractTestClasses.ts
+++ b/src/service/extractTestClasses.ts
@@ -3,7 +3,7 @@
 import { retrieveCommitMessages } from './retrieveCommitMessages.js';
 import { resolveTestSuites } from './resolveTestSuites.js';
 import { validateClassPaths } from './validateClassPaths.js';
-import { gitAdapter } from './gitAdapter.js';
+import { openRepo } from './gitAdapter.js';
 
 export async function extractTestClasses(
   fromRef: string,
@@ -12,47 +12,51 @@ export async function extractTestClasses(
   baseDir?: string,
 ): Promise<{ validatedClasses: string; warnings: string[]; suites: string[] }> {
   const localTestClasses: Set<string> = new Set();
-  const git = gitAdapter(baseDir);
-  const { repoRoot, matchedMessages, matchedSuites } = await retrieveCommitMessages(fromRef, toRef, git);
+  const repo = await openRepo(baseDir);
+  try {
+    const { repoRoot, matchedMessages, matchedSuites } = await retrieveCommitMessages(fromRef, toRef, repo);
 
-  matchedMessages.forEach((message: string) => {
-    // Split the commit message by commas or spaces
-    const classes = message.split(/,|\s/);
+    matchedMessages.forEach((message: string) => {
+      // Split the commit message by commas or spaces
+      const classes = message.split(/,|\s/);
 
-    classes.forEach((testClass: string) => {
-      // Remove leading/trailing whitespaces and add non-empty strings to the set
-      const trimmedClass = testClass.trim();
-      if (trimmedClass !== '') {
-        localTestClasses.add(trimmedClass);
-      }
+      classes.forEach((testClass: string) => {
+        // Remove leading/trailing whitespaces and add non-empty strings to the set
+        const trimmedClass = testClass.trim();
+        if (trimmedClass !== '') {
+          localTestClasses.add(trimmedClass);
+        }
+      });
     });
-  });
 
-  const suiteResult = await resolveTestSuites(matchedSuites, toRef, repoRoot, git);
-  suiteResult.localClasses.forEach((className) => localTestClasses.add(className));
+    const suiteResult = await resolveTestSuites(matchedSuites, toRef, repoRoot, repo);
+    suiteResult.localClasses.forEach((className) => localTestClasses.add(className));
 
-  const sortedLocal = Array.from(localTestClasses).sort((a, b) => a.localeCompare(b));
+    const sortedLocal = Array.from(localTestClasses).sort((a, b) => a.localeCompare(b));
 
-  if (skipValidate) {
-    const combined = mergeAndSort(sortedLocal, suiteResult.namespacedClasses);
+    if (skipValidate) {
+      const combined = mergeAndSort(sortedLocal, suiteResult.namespacedClasses);
+      return {
+        validatedClasses: combined,
+        warnings: suiteResult.warnings,
+        suites: suiteResult.resolvedSuites,
+      };
+    }
+
+    const validation =
+      sortedLocal.length > 0
+        ? await validateClassPaths(sortedLocal, toRef, repoRoot, repo)
+        : { validatedClasses: new Set<string>(), warnings: [] as string[] };
+
+    const combined = mergeAndSort(Array.from(validation.validatedClasses), suiteResult.namespacedClasses);
     return {
       validatedClasses: combined,
-      warnings: suiteResult.warnings,
+      warnings: [...suiteResult.warnings, ...validation.warnings],
       suites: suiteResult.resolvedSuites,
     };
+  } finally {
+    await repo.dispose();
   }
-
-  const validation =
-    sortedLocal.length > 0
-      ? await validateClassPaths(sortedLocal, toRef, repoRoot, git)
-      : { validatedClasses: new Set<string>(), warnings: [] as string[] };
-
-  const combined = mergeAndSort(Array.from(validation.validatedClasses), suiteResult.namespacedClasses);
-  return {
-    validatedClasses: combined,
-    warnings: [...suiteResult.warnings, ...validation.warnings],
-    suites: suiteResult.resolvedSuites,
-  };
 }
 
 function mergeAndSort(localClasses: string[], namespacedClasses: Set<string>): string {

--- a/src/service/getRepoRoot.ts
+++ b/src/service/getRepoRoot.ts
@@ -1,6 +1,7 @@
 'use strict';
-import { SimpleGit } from 'simple-git';
 
-export async function getRepoRoot(git: SimpleGit): Promise<string> {
-  return (await git.revparse('--show-toplevel')).trim();
+import type { Repository } from '@scolladon/tsgit';
+
+export function getRepoRoot(repo: Repository): string {
+  return repo.primitives.getRepoRoot();
 }

--- a/src/service/gitAdapter.ts
+++ b/src/service/gitAdapter.ts
@@ -1,11 +1,61 @@
-import { simpleGit, SimpleGit, SimpleGitOptions } from 'simple-git';
+'use strict';
+/* eslint-disable no-await-in-loop */
 
-export function gitAdapter(baseDir?: string): SimpleGit {
-  const options: Partial<SimpleGitOptions> = {
-    baseDir: baseDir ?? process.cwd(),
-    binary: 'git',
-    maxConcurrentProcesses: 6,
-    trimmed: true,
-  };
-  return simpleGit(options);
+import { openRepository, type Repository } from '@scolladon/tsgit';
+
+export async function openRepo(baseDir?: string): Promise<Repository> {
+  return openRepository({ cwd: baseDir ?? process.cwd() });
 }
+
+export async function listFilesAtCommit(repo: Repository, commitHash: string, directory: string): Promise<string[]> {
+  try {
+    const commitOid = await repo.revParse(commitHash);
+    const commitObj = await repo.primitives.readObject(commitOid);
+    if (commitObj.type !== 'commit') return [];
+    let treeOid = commitObj.data.tree;
+    for (const part of directory.split('/').filter(Boolean)) {
+      const tree = await repo.primitives.readTree(treeOid);
+      const entry = tree.entries.find((e) => e.name === part);
+      if (!entry) return [];
+      treeOid = entry.id;
+    }
+    const files: string[] = [];
+    for await (const entry of repo.primitives.walkTree(treeOid, { recursive: true })) {
+      if (entry.mode !== '40000') {
+        files.push(`${directory}/${entry.path}`);
+      }
+    }
+    return files;
+  } catch {
+    return [];
+  }
+}
+
+export async function readBlobAtCommitPath(
+  repo: Repository,
+  commitHash: string,
+  filePath: string,
+): Promise<Uint8Array | null> {
+  try {
+    const commitOid = await repo.revParse(commitHash);
+    const commitObj = await repo.primitives.readObject(commitOid);
+    if (commitObj.type !== 'commit') return null;
+    let treeOid = commitObj.data.tree;
+    const parts = filePath.split('/').filter(Boolean);
+    for (let i = 0; i < parts.length - 1; i++) {
+      const tree = await repo.primitives.readTree(treeOid);
+      const entry = tree.entries.find((e) => e.name === parts[i]);
+      if (!entry) return null;
+      treeOid = entry.id;
+    }
+    const lastTree = await repo.primitives.readTree(treeOid);
+    const fileEntry = lastTree.entries.find((e) => e.name === parts[parts.length - 1]);
+    if (!fileEntry) return null;
+    const blob = await repo.primitives.readBlob(fileEntry.id);
+    return blob.content;
+  } catch {
+    return null;
+  }
+}
+
+export type { Repository };

--- a/src/service/resolveTestSuites.ts
+++ b/src/service/resolveTestSuites.ts
@@ -36,14 +36,7 @@ export async function resolveTestSuites(
   const localClassInventory = await listLocalClasses(packageDirectories, toCommitHash, repo);
 
   for (const suiteName of uniqueSuites) {
-    const suiteFile = `${suiteName}.testSuite-meta.xml`;
-    let matchedPath: string | undefined;
-    for (const packageDirectory of packageDirectories) {
-      const files = await listFilesAtCommit(repo, toCommitHash, packageDirectory);
-      matchedPath = files.find((file) => file.endsWith(`/${suiteFile}`) || file === suiteFile);
-      if (matchedPath) break;
-    }
-
+    const matchedPath = await findSuitePath(suiteName, packageDirectories, toCommitHash, repo);
     if (!matchedPath) {
       warnings.push(
         `The test suite ${suiteName} was not found in any package directory at commit ${toCommitHash} and will not contribute test classes.`,
@@ -51,16 +44,13 @@ export async function resolveTestSuites(
       continue;
     }
 
-    const blobContent = await readBlobAtCommitPath(repo, toCommitHash, matchedPath);
-    if (!blobContent) {
+    const entries = await parseSuiteEntries(matchedPath, toCommitHash, repo, parser);
+    if (entries === null) {
       warnings.push(
         `The test suite ${suiteName} file could not be read at commit ${toCommitHash} and will not contribute test classes.`,
       );
       continue;
     }
-    const xml = new TextDecoder().decode(blobContent);
-    const parsed = parser.parse(xml) as { ApexTestSuite?: { testClassName?: string[] } };
-    const entries = parsed?.ApexTestSuite?.testClassName ?? [];
     if (entries.length === 0) {
       warnings.push(`The test suite ${suiteName} at commit ${toCommitHash} has no testClassName entries.`);
       continue;
@@ -72,6 +62,34 @@ export async function resolveTestSuites(
 
   resolvedSuites.sort((a, b) => a.localeCompare(b));
   return { localClasses, namespacedClasses, resolvedSuites, warnings };
+}
+
+async function findSuitePath(
+  suiteName: string,
+  packageDirectories: string[],
+  toCommitHash: string,
+  repo: Repository,
+): Promise<string | undefined> {
+  const suiteFile = `${suiteName}.testSuite-meta.xml`;
+  for (const packageDirectory of packageDirectories) {
+    const files = await listFilesAtCommit(repo, toCommitHash, packageDirectory);
+    const match = files.find((file) => file.endsWith(`/${suiteFile}`) || file === suiteFile);
+    if (match) return match;
+  }
+  return undefined;
+}
+
+async function parseSuiteEntries(
+  matchedPath: string,
+  toCommitHash: string,
+  repo: Repository,
+  parser: XMLParser,
+): Promise<string[] | null> {
+  const blobContent = await readBlobAtCommitPath(repo, toCommitHash, matchedPath);
+  if (!blobContent) return null;
+  const xml = new TextDecoder().decode(blobContent);
+  const parsed = parser.parse(xml) as { ApexTestSuite?: { testClassName?: string[] } };
+  return parsed?.ApexTestSuite?.testClassName ?? [];
 }
 
 async function listLocalClasses(

--- a/src/service/resolveTestSuites.ts
+++ b/src/service/resolveTestSuites.ts
@@ -2,10 +2,11 @@
 /* eslint-disable no-await-in-loop */
 
 import { basename } from 'node:path';
-import { SimpleGit } from 'simple-git';
+import type { Repository } from '@scolladon/tsgit';
 import { XMLParser } from 'fast-xml-parser';
 
 import { getPackageDirectories } from './getPackageDirectories.js';
+import { listFilesAtCommit, readBlobAtCommitPath } from './gitAdapter.js';
 
 export type ResolvedTestSuites = {
   localClasses: Set<string>;
@@ -18,7 +19,7 @@ export async function resolveTestSuites(
   suiteNames: string[],
   toCommitHash: string,
   repoRoot: string,
-  git: SimpleGit,
+  repo: Repository,
 ): Promise<ResolvedTestSuites> {
   const localClasses: Set<string> = new Set();
   const namespacedClasses: Set<string> = new Set();
@@ -32,13 +33,13 @@ export async function resolveTestSuites(
   const packageDirectories = await getPackageDirectories(repoRoot);
   const parser = new XMLParser({ isArray: (name) => name === 'testClassName' });
   const uniqueSuites = Array.from(new Set(suiteNames));
-  const localClassInventory = await listLocalClasses(packageDirectories, toCommitHash, git);
+  const localClassInventory = await listLocalClasses(packageDirectories, toCommitHash, repo);
 
   for (const suiteName of uniqueSuites) {
     const suiteFile = `${suiteName}.testSuite-meta.xml`;
     let matchedPath: string | undefined;
     for (const packageDirectory of packageDirectories) {
-      const files = (await git.raw('ls-tree', '--name-only', '-r', toCommitHash, packageDirectory)).trim().split('\n');
+      const files = await listFilesAtCommit(repo, toCommitHash, packageDirectory);
       matchedPath = files.find((file) => file.endsWith(`/${suiteFile}`) || file === suiteFile);
       if (matchedPath) break;
     }
@@ -50,7 +51,14 @@ export async function resolveTestSuites(
       continue;
     }
 
-    const xml = await git.show([`${toCommitHash}:${matchedPath}`]);
+    const blobContent = await readBlobAtCommitPath(repo, toCommitHash, matchedPath);
+    if (!blobContent) {
+      warnings.push(
+        `The test suite ${suiteName} file could not be read at commit ${toCommitHash} and will not contribute test classes.`,
+      );
+      continue;
+    }
+    const xml = new TextDecoder().decode(blobContent);
     const parsed = parser.parse(xml) as { ApexTestSuite?: { testClassName?: string[] } };
     const entries = parsed?.ApexTestSuite?.testClassName ?? [];
     if (entries.length === 0) {
@@ -69,11 +77,11 @@ export async function resolveTestSuites(
 async function listLocalClasses(
   packageDirectories: string[],
   toCommitHash: string,
-  git: SimpleGit,
+  repo: Repository,
 ): Promise<Set<string>> {
   const classes: Set<string> = new Set();
   for (const directory of packageDirectories) {
-    const files = (await git.raw('ls-tree', '--name-only', '-r', toCommitHash, directory)).trim().split('\n');
+    const files = await listFilesAtCommit(repo, toCommitHash, directory);
     for (const file of files) {
       if (file.endsWith('.cls')) {
         classes.add(basename(file, '.cls'));

--- a/src/service/retrieveCommitMessages.ts
+++ b/src/service/retrieveCommitMessages.ts
@@ -2,20 +2,20 @@
 
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import { DefaultLogFields, LogResult, SimpleGit } from 'simple-git';
+import type { Repository } from '@scolladon/tsgit';
 
 import { getRepoRoot } from './getRepoRoot.js';
 
 export async function retrieveCommitMessages(
   fromCommit: string,
   toCommit: string,
-  git: SimpleGit,
+  repo: Repository,
 ): Promise<{ repoRoot: string; matchedMessages: string[]; matchedSuites: string[] }> {
-  const repoRoot = await getRepoRoot(git);
-  const result: LogResult<string | DefaultLogFields> = await git.log({ from: fromCommit, to: toCommit, format: '%s' });
-
-  // Filter only entries that match the DefaultLogFields type
-  const commitMessages: string[] = (result.all as DefaultLogFields[]).map((commit) => commit.message);
+  const repoRoot = getRepoRoot(repo);
+  const fromOid = await repo.revParse(fromCommit);
+  const toOid = await repo.revParse(toCommit);
+  const entries = await repo.log({ from: String(toOid), excluding: [String(fromOid)] });
+  const commitMessages: string[] = entries.map((entry) => entry.message.split('\n')[0]);
 
   //  Read and compile the regex(es) from the specified file
   //  Line 1 = class regex (required), Line 2 = suite regex (optional)

--- a/src/service/validateClassPaths.ts
+++ b/src/service/validateClassPaths.ts
@@ -1,15 +1,16 @@
 'use strict';
 /* eslint-disable no-await-in-loop */
 
-import { SimpleGit } from 'simple-git';
+import type { Repository } from '@scolladon/tsgit';
 
 import { getPackageDirectories } from './getPackageDirectories.js';
+import { listFilesAtCommit } from './gitAdapter.js';
 
 export async function validateClassPaths(
   unvalidatedClasses: string[],
   toCommitHash: string,
   repoRoot: string,
-  git: SimpleGit
+  repo: Repository,
 ): Promise<{ validatedClasses: Set<string>; warnings: string[] }> {
   const packageDirectories = await getPackageDirectories(repoRoot);
   const warnings: string[] = [];
@@ -18,7 +19,7 @@ export async function validateClassPaths(
   for (const unvalidatedClass of unvalidatedClasses) {
     let validated: boolean = false;
     for (const packageDirectory of packageDirectories) {
-      const fileExists = await fileExistsInCommit(`${unvalidatedClass}.cls`, toCommitHash, packageDirectory, git);
+      const fileExists = await fileExistsInCommit(`${unvalidatedClass}.cls`, toCommitHash, packageDirectory, repo);
       if (fileExists) {
         validatedClasses.add(unvalidatedClass);
         validated = true;
@@ -27,17 +28,18 @@ export async function validateClassPaths(
     }
     if (!validated)
       warnings.push(
-        `The class ${unvalidatedClass} was not found in any package directory found in commit ${toCommitHash} and will not be added to the delta test classes.`
+        `The class ${unvalidatedClass} was not found in any package directory found in commit ${toCommitHash} and will not be added to the delta test classes.`,
       );
   }
   return { validatedClasses, warnings };
 }
+
 async function fileExistsInCommit(
   filePath: string,
   commitHash: string,
   directory: string,
-  git: SimpleGit
+  repo: Repository,
 ): Promise<boolean> {
-  const files = (await git.raw('ls-tree', '--name-only', '-r', commitHash, directory)).trim().split('\n');
+  const files = await listFilesAtCommit(repo, commitHash, directory);
   return files.some((file) => file.endsWith(filePath));
 }

--- a/test/commands/delta/delta.nut.ts
+++ b/test/commands/delta/delta.nut.ts
@@ -4,7 +4,7 @@ import { rm } from 'node:fs/promises';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-import { SimpleGit } from 'simple-git';
+import type { Repository } from '@scolladon/tsgit';
 
 import { createTemporaryCommit } from '../../utils/createTemporaryCommit.js';
 import { setupTestRepo } from '../../utils/setupTestRepo.js';
@@ -12,52 +12,59 @@ import { setupTestRepo } from '../../utils/setupTestRepo.js';
 describe('atgd NUTs', () => {
   let session: TestSession;
   let tempDir: string;
-  let git: SimpleGit;
+  let repo: Repository;
   const originalDir = process.cwd();
 
   beforeAll(async () => {
     session = await TestSession.create({ devhubAuthStrategy: 'NONE' });
-    ({ tempDir, git } = await setupTestRepo());
+    ({ tempDir, repo } = await setupTestRepo());
     process.chdir(tempDir);
     await createTemporaryCommit(
       'chore: commit with Apex::TestClass00::Apex',
       'force-app/main/default/classes/SandboxTest.cls',
       'dummy 1',
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: 2nd commit with Apex::SandboxTest::Apex',
       'force-app/main/default/classes/TestClass3.cls',
       'dummy 11',
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: adding new tests Apex::TestClass3 TestClass4::Apex',
       'packaged/classes/TestClass4.cls',
       'dummy 2',
-      git,
+      repo,
       tempDir,
     );
-    await createTemporaryCommit('chore: add some tests', 'packaged/classes/TestClass4.cls', 'dummy 2222', git, tempDir);
+    await createTemporaryCommit(
+      'chore: add some tests',
+      'packaged/classes/TestClass4.cls',
+      'dummy 2222',
+      repo,
+      tempDir,
+    );
     await createTemporaryCommit(
       'chore: adding new tests Apex::TestClass33::Apex',
       'TestClass4.cls',
       'dummy 22',
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: adding new tests Apex::TestClass33::Apex',
       'TestClass4.cls',
       'dummy 2',
-      git,
+      repo,
       tempDir,
     );
   });
 
   afterAll(async () => {
+    await repo.dispose();
     await session?.clean();
     process.chdir(originalDir);
     await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });

--- a/test/commands/delta/delta.test.ts
+++ b/test/commands/delta/delta.test.ts
@@ -2,7 +2,7 @@
 
 import { rm } from 'node:fs/promises';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { SimpleGit } from 'simple-git';
+import type { Repository } from '@scolladon/tsgit';
 
 import { extractTestClasses } from '../../../src/service/extractTestClasses.js';
 import { createTemporaryCommit } from '../../utils/createTemporaryCommit.js';
@@ -10,49 +10,56 @@ import { setupTestRepo } from '../../utils/setupTestRepo.js';
 
 describe('atgd unit test', () => {
   let tempDir: string;
-  let git: SimpleGit;
+  let repo: Repository;
 
   beforeAll(async () => {
-    ({ tempDir, git } = await setupTestRepo());
+    ({ tempDir, repo } = await setupTestRepo());
     await createTemporaryCommit(
       'chore: commit with Apex::TestClass00::Apex',
       'force-app/main/default/classes/SandboxTest.cls',
       'dummy 1',
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: 2nd commit with Apex::SandboxTest::Apex',
       'force-app/main/default/classes/TestClass3.cls',
       'dummy 11',
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: adding new tests Apex::TestClass3 TestClass4::Apex',
       'packaged/classes/TestClass4.cls',
       'dummy 2',
-      git,
+      repo,
       tempDir,
     );
-    await createTemporaryCommit('chore: add some tests', 'packaged/classes/TestClass4.cls', 'dummy 2222', git, tempDir);
+    await createTemporaryCommit(
+      'chore: add some tests',
+      'packaged/classes/TestClass4.cls',
+      'dummy 2222',
+      repo,
+      tempDir,
+    );
     await createTemporaryCommit(
       'chore: adding new tests Apex::  TestClass33   ::Apex',
       'TestClass4.cls',
       'dummy 22',
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: adding new tests Apex::TestClass33::Apex',
       'TestClass4.cls',
       'dummy 2',
-      git,
+      repo,
       tempDir,
     );
   });
 
   afterAll(async () => {
+    await repo.dispose();
     await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
   });
 

--- a/test/commands/delta/testSuite.test.ts
+++ b/test/commands/delta/testSuite.test.ts
@@ -3,7 +3,7 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { SimpleGit } from 'simple-git';
+import type { Repository } from '@scolladon/tsgit';
 
 import { extractTestClasses } from '../../../src/service/extractTestClasses.js';
 import { createTemporaryCommit } from '../../utils/createTemporaryCommit.js';
@@ -21,10 +21,10 @@ const suiteXml = (classes: string[]): string =>
 
 describe('atgd test suite parsing', () => {
   let tempDir: string;
-  let git: SimpleGit;
+  let repo: Repository;
 
   beforeAll(async () => {
-    ({ tempDir, git } = await setupTestRepo());
+    ({ tempDir, repo } = await setupTestRepo());
 
     // Overwrite the rc file with a two-line version that also recognizes Suite::<name>::Suite markers.
     await writeFile(
@@ -38,21 +38,21 @@ describe('atgd test suite parsing', () => {
       'chore: seed Apex::SeedTest::Apex',
       'force-app/main/default/classes/SeedTest.cls',
       'public with sharing class SeedTest {}',
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: add suite members',
       'force-app/main/default/classes/AccountTest.cls',
       'public with sharing class AccountTest {}',
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: add second suite member',
       'force-app/main/default/classes/ContactTest.cls',
       'public with sharing class ContactTest {}',
-      git,
+      repo,
       tempDir,
     );
     // Commit the test suite metadata file.
@@ -60,7 +60,7 @@ describe('atgd test suite parsing', () => {
       'chore: add MyRegressionSuite',
       'force-app/main/default/testSuites/MyRegressionSuite.testSuite-meta.xml',
       suiteXml(['AccountTest', 'ContactTest']),
-      git,
+      repo,
       tempDir,
     );
     // Commit referencing the suite in the message.
@@ -68,7 +68,7 @@ describe('atgd test suite parsing', () => {
       'chore: regression pass Suite::MyRegressionSuite::Suite',
       'force-app/main/default/classes/ContactTest.cls',
       'public with sharing class ContactTest { /* v2 */ }',
-      git,
+      repo,
       tempDir,
     );
     // Commit referencing a missing suite plus a direct class.
@@ -76,7 +76,7 @@ describe('atgd test suite parsing', () => {
       'chore: misc Suite::NonExistentSuite::Suite Apex::SeedTest::Apex',
       'force-app/main/default/classes/SeedTest.cls',
       'public with sharing class SeedTest { /* v2 */ }',
-      git,
+      repo,
       tempDir,
     );
     // Commit an empty suite and reference it.
@@ -84,19 +84,20 @@ describe('atgd test suite parsing', () => {
       'chore: add empty suite',
       'force-app/main/default/testSuites/EmptySuite.testSuite-meta.xml',
       suiteXml([]),
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: run empty Suite::EmptySuite::Suite',
       'force-app/main/default/classes/SeedTest.cls',
       'public with sharing class SeedTest { /* v3 */ }',
-      git,
+      repo,
       tempDir,
     );
   });
 
   afterAll(async () => {
+    await repo.dispose();
     await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
   });
 
@@ -131,10 +132,10 @@ describe('atgd test suite parsing', () => {
 
 describe('atgd test suite wildcards and namespaces', () => {
   let tempDir: string;
-  let git: SimpleGit;
+  let repo: Repository;
 
   beforeAll(async () => {
-    ({ tempDir, git } = await setupTestRepo());
+    ({ tempDir, repo } = await setupTestRepo());
     await writeFile(
       join(tempDir, regExFile),
       ['[Aa][Pp][Ee][Xx]::(.*?)::[Aa][Pp][Ee][Xx]', '[Ss][Uu][Ii][Tt][Ee]::(.*?)::[Ss][Uu][Ii][Tt][Ee]'].join('\n'),
@@ -146,35 +147,35 @@ describe('atgd test suite wildcards and namespaces', () => {
       'chore: add AClass',
       'force-app/main/default/classes/AClass.cls',
       'public with sharing class AClass {}',
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: add AnotherClass',
       'force-app/main/default/classes/AnotherClass.cls',
       'public with sharing class AnotherClass {}',
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: add AwesomeClass',
       'force-app/main/default/classes/AwesomeClass.cls',
       'public with sharing class AwesomeClass {}',
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: add LocalTestClass',
       'force-app/main/default/classes/LocalTestClass.cls',
       'public with sharing class LocalTestClass {}',
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: add Unrelated',
       'force-app/main/default/classes/Unrelated.cls',
       'public with sharing class Unrelated {}',
-      git,
+      repo,
       tempDir,
     );
     // The wildcard suite mirrors the API doc example.
@@ -182,14 +183,14 @@ describe('atgd test suite wildcards and namespaces', () => {
       'chore: add WildcardSuite',
       'force-app/main/default/testSuites/WildcardSuite.testSuite-meta.xml',
       suiteXml(['LocalTestClass', 'A*Class', 'Namespace1.NamespacedTestClass', 'Namespace1.*']),
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: run Suite::WildcardSuite::Suite',
       'force-app/main/default/classes/AClass.cls',
       'public with sharing class AClass { /* v2 */ }',
-      git,
+      repo,
       tempDir,
     );
     // A second suite using a pattern that doesn't match anything to exercise the no-match warning.
@@ -197,14 +198,14 @@ describe('atgd test suite wildcards and namespaces', () => {
       'chore: add NoMatchSuite',
       'force-app/main/default/testSuites/NoMatchSuite.testSuite-meta.xml',
       suiteXml(['Zzz*Nope']),
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: run Suite::NoMatchSuite::Suite',
       'force-app/main/default/classes/AClass.cls',
       'public with sharing class AClass { /* v3 */ }',
-      git,
+      repo,
       tempDir,
     );
     // A suite using pure '*' to grab every local class.
@@ -212,19 +213,20 @@ describe('atgd test suite wildcards and namespaces', () => {
       'chore: add AllSuite',
       'force-app/main/default/testSuites/AllSuite.testSuite-meta.xml',
       suiteXml(['*']),
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: run Suite::AllSuite::Suite',
       'force-app/main/default/classes/AClass.cls',
       'public with sharing class AClass { /* v4 */ }',
-      git,
+      repo,
       tempDir,
     );
   });
 
   afterAll(async () => {
+    await repo.dispose();
     await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
   });
 
@@ -270,10 +272,10 @@ describe('atgd test suite wildcards and namespaces', () => {
 
 describe('atgd test suite blank entries', () => {
   let tempDir: string;
-  let git: SimpleGit;
+  let repo: Repository;
 
   beforeAll(async () => {
-    ({ tempDir, git } = await setupTestRepo());
+    ({ tempDir, repo } = await setupTestRepo());
     await writeFile(
       join(tempDir, regExFile),
       ['[Aa][Pp][Ee][Xx]::(.*?)::[Aa][Pp][Ee][Xx]', '[Ss][Uu][Ii][Tt][Ee]::(.*?)::[Ss][Uu][Ii][Tt][Ee]'].join('\n'),
@@ -284,7 +286,7 @@ describe('atgd test suite blank entries', () => {
       'chore: add BlankTest',
       'force-app/main/default/classes/BlankTest.cls',
       'public with sharing class BlankTest {}',
-      git,
+      repo,
       tempDir,
     );
     // Suite mixes a real entry with blank/whitespace-only <testClassName> elements to
@@ -293,19 +295,20 @@ describe('atgd test suite blank entries', () => {
       'chore: add BlankSuite',
       'force-app/main/default/testSuites/BlankSuite.testSuite-meta.xml',
       suiteXml(['BlankTest', '', '   ']),
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: run Suite::BlankSuite::Suite',
       'force-app/main/default/classes/BlankTest.cls',
       'public with sharing class BlankTest { /* v2 */ }',
-      git,
+      repo,
       tempDir,
     );
   });
 
   afterAll(async () => {
+    await repo.dispose();
     await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
   });
 
@@ -319,27 +322,28 @@ describe('atgd test suite blank entries', () => {
 
 describe('atgd backward-compatible single-line rc', () => {
   let tempDir: string;
-  let git: SimpleGit;
+  let repo: Repository;
 
   beforeAll(async () => {
-    ({ tempDir, git } = await setupTestRepo());
+    ({ tempDir, repo } = await setupTestRepo());
     await createTemporaryCommit(
       'chore: initial',
       'force-app/main/default/classes/InitialTest.cls',
       'public with sharing class InitialTest {}',
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: only classes Apex::LonelyTest::Apex',
       'force-app/main/default/classes/LonelyTest.cls',
       'public with sharing class LonelyTest {}',
-      git,
+      repo,
       tempDir,
     );
   });
 
   afterAll(async () => {
+    await repo.dispose();
     await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
   });
 

--- a/test/units/gitAdapter.test.ts
+++ b/test/units/gitAdapter.test.ts
@@ -2,13 +2,33 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { openRepo } from '../../src/service/gitAdapter.js';
+import { openRepo, listFilesAtCommit, readBlobAtCommitPath } from '../../src/service/gitAdapter.js';
+
+const NONEXISTENT_SHA = '0000000000000000000000000000000000000001';
 
 describe('openRepo', () => {
   it('defaults baseDir to process.cwd() when no argument provided', async () => {
     const repo = await openRepo();
     const root = repo.primitives.getRepoRoot();
     expect(root).toBeTruthy();
+    await repo.dispose();
+  });
+});
+
+describe('listFilesAtCommit', () => {
+  it('returns empty array when commit object does not exist', async () => {
+    const repo = await openRepo();
+    const files = await listFilesAtCommit(repo, NONEXISTENT_SHA, 'src');
+    expect(files).toEqual([]);
+    await repo.dispose();
+  });
+});
+
+describe('readBlobAtCommitPath', () => {
+  it('returns null when commit object does not exist', async () => {
+    const repo = await openRepo();
+    const content = await readBlobAtCommitPath(repo, NONEXISTENT_SHA, 'src/index.ts');
+    expect(content).toBeNull();
     await repo.dispose();
   });
 });

--- a/test/units/gitAdapter.test.ts
+++ b/test/units/gitAdapter.test.ts
@@ -2,12 +2,13 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { gitAdapter } from '../../src/service/gitAdapter.js';
+import { openRepo } from '../../src/service/gitAdapter.js';
 
-describe('gitAdapter', () => {
+describe('openRepo', () => {
   it('defaults baseDir to process.cwd() when no argument provided', async () => {
-    const git = gitAdapter();
-    const root = await git.revparse('--show-toplevel');
+    const repo = await openRepo();
+    const root = repo.primitives.getRepoRoot();
     expect(root).toBeTruthy();
+    await repo.dispose();
   });
 });

--- a/test/units/invalidRegex.test.ts
+++ b/test/units/invalidRegex.test.ts
@@ -3,7 +3,7 @@
 import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { SimpleGit } from 'simple-git';
+import type { Repository } from '@scolladon/tsgit';
 
 import { extractTestClasses } from '../../src/service/extractTestClasses.js';
 import { createTemporaryCommit } from '../utils/createTemporaryCommit.js';
@@ -12,23 +12,23 @@ import { regExFile } from '../utils/testConstants.js';
 
 describe('atgd unit test', () => {
   let tempDir: string;
-  let git: SimpleGit;
+  let repo: Repository;
   let regExFilePath: string;
 
   beforeAll(async () => {
-    ({ tempDir, git } = await setupTestRepo());
+    ({ tempDir, repo } = await setupTestRepo());
     await createTemporaryCommit(
       'chore: commit with Apex::::Apex',
       'force-app/main/default/classes/SandboxTest.cls',
       'dummy 1',
-      git,
+      repo,
       tempDir,
     );
     await createTemporaryCommit(
       'chore: 2nd commit with Apex::::Apex',
       'force-app/main/default/classes/TestClass3.cls',
       'dummy 11',
-      git,
+      repo,
       tempDir,
     );
     regExFilePath = join(tempDir, regExFile);
@@ -36,6 +36,7 @@ describe('atgd unit test', () => {
   });
 
   afterAll(async () => {
+    await repo.dispose();
     await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
   });
 

--- a/test/units/resolveTestSuites.test.ts
+++ b/test/units/resolveTestSuites.test.ts
@@ -1,0 +1,54 @@
+'use strict';
+
+import { rm, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Repository } from '@scolladon/tsgit';
+
+vi.mock('../../src/service/gitAdapter.js', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../../src/service/gitAdapter.js')>();
+  return { ...mod, readBlobAtCommitPath: vi.fn(mod.readBlobAtCommitPath) };
+});
+
+import { resolveTestSuites } from '../../src/service/resolveTestSuites.js';
+import * as gitAdapter from '../../src/service/gitAdapter.js';
+import { createTemporaryCommit } from '../utils/createTemporaryCommit.js';
+import { setupTestRepo } from '../utils/setupTestRepo.js';
+
+const suiteXml = (): string =>
+  [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<ApexTestSuite xmlns="http://soap.sforce.com/2006/04/metadata">',
+    '    <testClassName>SomeTest</testClassName>',
+    '</ApexTestSuite>',
+    '',
+  ].join('\n');
+
+describe('resolveTestSuites blob-read failure', () => {
+  let tempDir: string;
+  let repo: Repository;
+
+  beforeAll(async () => {
+    ({ tempDir, repo } = await setupTestRepo());
+    await mkdir(join(tempDir, 'force-app/main/default/testSuites'), { recursive: true });
+    await createTemporaryCommit(
+      'chore: add suite',
+      'force-app/main/default/testSuites/BlobFailSuite.testSuite-meta.xml',
+      suiteXml(),
+      repo,
+      tempDir,
+    );
+  });
+
+  afterAll(async () => {
+    await repo.dispose();
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+  });
+
+  it('warns when suite file blob cannot be read', async () => {
+    vi.mocked(gitAdapter.readBlobAtCommitPath).mockResolvedValueOnce(null);
+    const result = await resolveTestSuites(['BlobFailSuite'], 'HEAD', tempDir, repo);
+    expect(result.resolvedSuites).toEqual([]);
+    expect(result.warnings.some((w) => w.includes('BlobFailSuite') && w.includes('could not be read'))).toBe(true);
+  });
+});

--- a/test/utils/createTemporaryCommit.ts
+++ b/test/utils/createTemporaryCommit.ts
@@ -2,24 +2,24 @@
 
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { SimpleGit } from 'simple-git';
+import type { Repository } from '@scolladon/tsgit';
 
 export async function createTemporaryCommit(
   message: string,
   filePath: string,
   content: string,
-  git: SimpleGit,
+  repo: Repository,
   baseDir: string,
 ): Promise<string> {
   await writeFile(join(baseDir, filePath), content);
   // Stage the file
-  await git.add(filePath);
+  await repo.add([filePath]);
 
   // Commit with the provided message
-  await git.commit(message);
+  await repo.commit({ message });
 
   // Return the commit hash of the newly created commit
-  const commitHash = (await git.revparse('HEAD')).trim();
+  const commitHash = String(await repo.revParse('HEAD'));
 
   return commitHash;
 }

--- a/test/utils/setupTestRepo.ts
+++ b/test/utils/setupTestRepo.ts
@@ -9,7 +9,7 @@ import { openRepository, type Repository } from '@scolladon/tsgit';
 import { regExFile, regExFileContents, sfdxConfigFile, sfdxConfigJsonString } from './testConstants.js';
 
 export async function setupTestRepo(): Promise<{ tempDir: string; repo: Repository }> {
-  const tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'git-temp-')));
+  const tempDir = realpathSync.native(mkdtempSync(join(tmpdir(), 'git-temp-')));
   const repo = await openRepository({ cwd: tempDir });
 
   await mkdir(join(tempDir, 'force-app/main/default/classes'), { recursive: true });

--- a/test/utils/setupTestRepo.ts
+++ b/test/utils/setupTestRepo.ts
@@ -3,24 +3,23 @@
 import { mkdtempSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
-import { SimpleGit } from 'simple-git';
+import { openRepository, type Repository } from '@scolladon/tsgit';
 
-import { gitAdapter } from '../../src/service/gitAdapter.js';
 import { regExFile, regExFileContents, sfdxConfigFile, sfdxConfigJsonString } from './testConstants.js';
 
-export async function setupTestRepo(): Promise<{ tempDir: string; git: SimpleGit }> {
+export async function setupTestRepo(): Promise<{ tempDir: string; repo: Repository }> {
   const tempDir = mkdtempSync(resolve('..', 'git-temp-'));
-  const git = gitAdapter(tempDir);
+  const repo = await openRepository({ cwd: tempDir });
 
   await mkdir(join(tempDir, 'force-app/main/default/classes'), { recursive: true });
   await mkdir(join(tempDir, 'packaged/classes'), { recursive: true });
-  await git.init();
+  await repo.init();
   await writeFile(join(tempDir, regExFile), regExFileContents);
   await writeFile(join(tempDir, sfdxConfigFile), sfdxConfigJsonString);
 
-  await git.addConfig('user.name', 'CI Bot', false, 'local');
-  await git.addConfig('user.email', '90224411+mcarvin8@users.noreply.github.com', false, 'local');
-  await git.addConfig('commit.gpgsign', 'false', false, 'local');
-  await git.addConfig('tag.gpgsign', 'false', false, 'local');
-  return { tempDir, git };
+  await repo.config.set({ key: 'user.name', value: 'CI Bot', scope: 'local' });
+  await repo.config.set({ key: 'user.email', value: '90224411+mcarvin8@users.noreply.github.com', scope: 'local' });
+  await repo.config.set({ key: 'commit.gpgsign', value: 'false', scope: 'local' });
+  await repo.config.set({ key: 'tag.gpgsign', value: 'false', scope: 'local' });
+  return { tempDir, repo };
 }

--- a/test/utils/setupTestRepo.ts
+++ b/test/utils/setupTestRepo.ts
@@ -2,13 +2,14 @@
 
 import { mkdtempSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { openRepository, type Repository } from '@scolladon/tsgit';
 
 import { regExFile, regExFileContents, sfdxConfigFile, sfdxConfigJsonString } from './testConstants.js';
 
 export async function setupTestRepo(): Promise<{ tempDir: string; repo: Repository }> {
-  const tempDir = mkdtempSync(resolve('..', 'git-temp-'));
+  const tempDir = mkdtempSync(join(tmpdir(), 'git-temp-'));
   const repo = await openRepository({ cwd: tempDir });
 
   await mkdir(join(tempDir, 'force-app/main/default/classes'), { recursive: true });

--- a/test/utils/setupTestRepo.ts
+++ b/test/utils/setupTestRepo.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, realpathSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -9,7 +9,7 @@ import { openRepository, type Repository } from '@scolladon/tsgit';
 import { regExFile, regExFileContents, sfdxConfigFile, sfdxConfigJsonString } from './testConstants.js';
 
 export async function setupTestRepo(): Promise<{ tempDir: string; repo: Repository }> {
-  const tempDir = mkdtempSync(join(tmpdir(), 'git-temp-'));
+  const tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'git-temp-')));
   const repo = await openRepository({ cwd: tempDir });
 
   await mkdir(join(tempDir, 'force-app/main/default/classes'), { recursive: true });


### PR DESCRIPTION
## Summary

- Replaces `simple-git` (git CLI wrapper) with `@scolladon/tsgit` (pure-TypeScript git implementation)
- Removes the runtime dependency on a git binary being present on `PATH`
- Bumps minimum Node.js engine requirement from `>=20.0.0` to `>=22.0.0` (required by tsgit)

## Breaking Changes

- **Node.js `>=22.0.0` required** — tsgit uses Node 22 native APIs not available in Node 20/21
- **`git` CLI no longer required at runtime** — all git operations are now handled in-process via tsgit

## Implementation Notes

- `gitAdapter.ts` — new `listFilesAtCommit` navigates commit → root tree → subdirectory via `readObject`/`readTree` primitives, then walks with `walkTree`. New `readBlobAtCommitPath` helper reads file content via same tree traversal.
- `retrieveCommitMessages.ts` — resolves both `from`/`to` refs to OIDs before passing to `repo.log()` (tsgit validates log params as ref names and rejects rev expressions containing `~`)
- `getRepoRoot.ts` — uses `repo.primitives.getRepoRoot()` instead of `git rev-parse --show-toplevel`
- All tests updated: `SimpleGit` → `Repository`, `setupTestRepo` uses tsgit `init`/`config.set`/`add`/`commit`

## Test plan

- [x] All 17 unit tests pass (`npx vitest run --coverage`)
- [x] TypeScript compiles clean for both `src` and `test` tsconfigs
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)