### PR TITLE
feat: add --format flag with space and sf output options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A Salesforce CLI plugin that extracts Apex test class names from git commit mess
   - [Run the command to extract tests](#run-the-command-to-extract-tests)
   - [Use the output in a deployment command](#use-the-output-in-a-deployment-command)
 - [`sf atgd delta`](#sf-atgd-delta)
+- [Output Formats](#output-formats)
 - [Alternatives](#alternatives)
 - [Issues](#issues)
 - [License](#license)
@@ -86,15 +87,24 @@ AccountTriggerHandlerTest OpportunityTriggerHandlerTest PrepareMySandboxTest Quo
 
 ### Use the output in a deployment command
 
+Use the default `space` format with `-t` (which accepts a space-separated list):
+
 ```bash
 sf project deploy start -x package/package.xml -l RunSpecifiedTests -t $(sf atgd delta --from "HEAD~1" --to "HEAD")
+```
+
+Use the `sf` format to inline tests directly into commands that expect repeated `--tests` flags (e.g. `sf apex run test`):
+
+```bash
+sf apex run test $(sf atgd delta --from "HEAD~1" --to "HEAD" --format sf)
+# expands to: sf apex run test --tests AccountTriggerHandlerTest --tests QuoteControllerTest ...
 ```
 
 ## `sf atgd delta`
 
 ```
 USAGE
-  $ sf atgd delta -f <value> -t <value> -v [--json]
+  $ sf atgd delta -f <value> -t <value> -v [-o space|sf] [--json]
 
 FLAGS
   -f, --from=<value>          Commit SHA from where the commit message log is done.
@@ -103,6 +113,8 @@ FLAGS
                               [default: HEAD]
   -v, --skip-test-validation  Skip validating that tests exist in the local package directories.
                               [default: false]
+  -o, --format=<option>       Output format for the test list.
+                              [default: space] <options: space|sf>
 
 GLOBAL FLAGS
   --json  Format output as json.
@@ -118,6 +130,23 @@ EXAMPLES
   Get tests from the most recent commit, skipping the local package directory validation.
 
     $ sf atgd delta --from "HEAD~1" --to "HEAD" -v
+
+  Get tests formatted for use with sf apex run test.
+
+    $ sf atgd delta --from "HEAD~1" --to "HEAD" --format sf
+```
+
+## Output Formats
+
+| Format            | Flag          | Output                                         | Use with                            |
+| ----------------- | ------------- | ---------------------------------------------- | ----------------------------------- |
+| `space` (default) | _(omit)_      | `ClassA ClassB ClassC`                         | `sf project deploy start -t $(...)` |
+| `sf`              | `--format sf` | `--tests ClassA --tests ClassB --tests ClassC` | `sf apex run test $(...)`           |
+
+The `sf` format lets you compose this plugin directly into Salesforce CLI commands without any shell post-processing:
+
+```bash
+sf apex run test $(sf atgd delta --from "HEAD~1" --to "HEAD" --format sf)
 ```
 
 ## Alternatives

--- a/messages/delta.md
+++ b/messages/delta.md
@@ -10,6 +10,8 @@ Determine Apex tests for incremental deployments by parsing commit messages betw
 
 - `sf atgd delta --from "HEAD~1" --to "HEAD"`
 - `sf atgd delta --from "HEAD~1" --to "HEAD" -v`
+- `sf atgd delta --from "HEAD~1" --to "HEAD" --format sf`
+- `sf apex run test $(sf atgd delta --from "HEAD~1" --to "HEAD" --format sf)`
 
 # flags.from.summary
 
@@ -22,3 +24,7 @@ Commit SHA to where the commit message log is done.
 # flags.skip-test-validation.summary
 
 Skip validating that tests exist in the local package directories.
+
+# flags.format.summary
+
+Output format for the test list. "space" (default) outputs a space-separated list. "sf" outputs each test prefixed with --tests for use in Salesforce CLI commands (e.g. --tests ClassA --tests ClassB).

--- a/src/commands/atgd/delta.ts
+++ b/src/commands/atgd/delta.ts
@@ -31,6 +31,13 @@ export default class ApexTestDelta extends SfCommand<TestDeltaResult> {
       required: true,
       default: false,
     }),
+    format: Flags.option({
+      options: ['space', 'sf'] as const,
+    })({
+      char: 'o',
+      summary: messages.getMessage('flags.format.summary'),
+      default: 'space',
+    }),
   };
 
   public async run(): Promise<TestDeltaResult> {
@@ -48,7 +55,15 @@ export default class ApexTestDelta extends SfCommand<TestDeltaResult> {
     if (suites.length > 0) {
       this.log(`Resolved test suites: ${suites.join(' ')}`);
     }
-    this.log(tests);
+    const output =
+      flags['format'] === 'sf'
+        ? tests
+            .split(' ')
+            .filter(Boolean)
+            .map((t) => `--tests ${t}`)
+            .join(' ')
+        : tests;
+    this.log(output);
     return { tests, warnings, suites };
   }
 }

--- a/test/commands/delta/delta.nut.ts
+++ b/test/commands/delta/delta.nut.ts
@@ -87,4 +87,9 @@ describe('atgd NUTs', () => {
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output.replace('\n', '')).toEqual('TestClass33');
   });
+  it('return tests in sf format', async () => {
+    const command = 'atgd delta --from "HEAD~5" --to "HEAD~3" --format sf';
+    const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
+    expect(output.replace('\n', '')).toEqual('--tests SandboxTest --tests TestClass3 --tests TestClass4');
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `-o`/`--format` flag to `atgd delta` with two options: `space` (default, existing behavior) and `sf`
- `sf` format prefixes each test class with `--tests` so output composes directly into `sf apex run test` commands
- Updates README with an Output Formats comparison table and inline usage examples
- Adds a NUT covering the new `--format sf` output

## Usage

```bash
# default (unchanged)
sf atgd delta --from "HEAD~1" --to "HEAD"
# → ClassA ClassB ClassC

# sf format — drops straight into Salesforce CLI
sf apex run test $(sf atgd delta --from "HEAD~1" --to "HEAD" --format sf)
# → sf apex run test --tests ClassA --tests ClassB --tests ClassC
```

## Test plan

- [x] Existing NUTs still pass (3 tests)
- [x] New NUT asserts `--format sf` produces `--tests X --tests Y ...` output
- [x] Build + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)