### PR TITLE
feat(deps): bump @scolladon/tsgit to v3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@oclif/core": "4.2.7",
         "@salesforce/core": "8.8.2",
         "@salesforce/sf-plugins-core": "12.1.4",
-        "@scolladon/tsgit": "2.0.1",
+        "@scolladon/tsgit": "3.0.0",
         "txml": "6.0.0"
       },
       "devDependencies": {
@@ -4625,9 +4625,9 @@
       }
     },
     "node_modules/@scolladon/tsgit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@scolladon/tsgit/-/tsgit-2.0.1.tgz",
-      "integrity": "sha512-+khAEX4zd2UeMcBQi6Ar8QDH5+IdoUir2LsQTjGNaYgj8wMWnTB5ANYbuGANfY2Um5sD5S/c0S/RZDRFDnm2WA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@scolladon/tsgit/-/tsgit-3.0.0.tgz",
+      "integrity": "sha512-WpPH1Q1xxzKsNribCb90fqFbW0GevbXpVtr/C9bvAUmf/cPMc8q/+iWmZaqqcpWl49qL5MnwdQOU0JByyNWqaQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.22.1"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@oclif/core": "4.2.7",
     "@salesforce/core": "8.8.2",
     "@salesforce/sf-plugins-core": "12.1.4",
-    "@scolladon/tsgit": "2.0.1",
+    "@scolladon/tsgit": "3.0.0",
     "txml": "6.0.0"
   },
   "devDependencies": {

--- a/src/service/retrieveCommitMessages.ts
+++ b/src/service/retrieveCommitMessages.ts
@@ -14,7 +14,7 @@ export async function retrieveCommitMessages(
   const repoRoot = getRepoRoot(repo);
   const fromOid = await repo.revParse(fromCommit);
   const toOid = await repo.revParse(toCommit);
-  const entries = await repo.log({ from: String(toOid), excluding: [String(fromOid)] });
+  const entries = await repo.log({ rev: String(toOid), excluding: [String(fromOid)] });
   const commitMessages: string[] = entries.map((entry) => entry.message.split('\n')[0]);
 
   //  Read and compile the regex(es) from the specified file


### PR DESCRIPTION
## Summary
- Bump `@scolladon/tsgit` 2.0.1 → 3.0.0
- v3's `log` primitive renamed the commit-ish option `from` → `rev`; updated `retrieveCommitMessages.ts` accordingly (only breaking change that touched this plugin's usage)

## Test plan
- [x] `npx tsc -p .` — clean
- [x] `npx tsc -p ./test` — clean
- [x] `npx vitest run --coverage` — 25 tests pass, 100% stmts/branch/funcs/lines
- [x] `npx biome check src test` — clean
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)